### PR TITLE
Oppgraderer Distroless til nodejs20-debian12@sha256:36a64f13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs20-debian12@sha256:04350092341fdc31bd1c9c7cac4f50f9194652f3afd8d4a442428b102c9d66c2
+FROM gcr.io/distroless/nodejs20-debian12@sha256:36a64f13fd57646fd2059f258f759a8d2ccfbca7a397c550b425c63171fc47cb
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Fra flex-cli